### PR TITLE
Fix nested dumps

### DIFF
--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -70,11 +70,12 @@ class Command(BaseCommand):
                 add_to_serialize_list([obj], serialize_me, seen)
 
         serialize_fully(serialize_me, seen)
-        data = serialize('json', [o for o in serialize_me if o is not None],
-                         indent=4,
-                         use_natural_foreign_keys=options.get('natural', False),
-                         use_natural_primary_keys=options.get('natural', False),
-                         )
+        data = serialize(
+            'json', [o for o in serialize_me if o is not None],
+            indent=4,
+            use_natural_foreign_keys=options.get('natural', False),
+            use_natural_primary_keys=options.get('natural', False),
+        )
 
         data = reorder_json(
             json.loads(data),

--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -59,17 +59,17 @@ class Command(BaseCommand):
         dump_settings = settings.CUSTOM_DUMPS[dump_name]
         app_label, model_name, *manager_method = dump_settings['primary'].split('.')
         include_primary = dump_settings.get("include_primary", False)
+
         default_manager = loading.get_model(app_label, model_name).objects
         if manager_method:
-            dump_me = getattr(default_manager, manager_method[0])()
+            queryset = getattr(default_manager, manager_method[0])()
         else:
-            dump_me = default_manager
+            queryset = default_manager.all()
         if pks:
-            objs = dump_me.filter(pk__in=pks)
-        else:
-            objs = dump_me
+            queryset = queryset.filter(pk__in=pks)
+
         deps = dump_settings.get('dependents', [])
-        for obj in objs.all():
+        for obj in queryset:
             # get the dependent objects and add to serialize list
             for dep in deps:
                 process_dep(obj, dep, serialize_me, seen)

--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -31,7 +31,7 @@ def process_dep(parent, dep):
     try:
         thing = getattr(parent, current)
     except AttributeError:
-        sys.stderr.write('%s.%s not found\n' % (parent, current))
+        pass  # related object not found
     else:
         if hasattr(thing, 'all'):
             children = thing.all()

--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -83,4 +83,4 @@ class Command(BaseCommand):
             ordering_cond=dump_settings.get('order_cond', {})
         )
 
-        print(json.dumps(data, indent=4))
+        self.stdout.write(json.dumps(data, indent=4))

--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
         include_primary = dump_settings.get("include_primary", False)
         dump_me = loading.get_model(app_label, model_name)
         objs = dump_me.objects.filter(pk__in=[int(i) for i in pks])
-        deps = dump_settings['dependents']
+        deps = dump_settings.get('dependents', [])
         for obj in objs.all():
             # get the dependent objects and add to serialize list
             for dep in deps:

--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -23,7 +23,7 @@ from fixture_magic.utils import (
 def process_dep(parent, dep, serialize_me, seen):
     parts = dep.split('.')
     current = parts.pop(0)
-    remain = '.'.join(parts)
+    leftover = '.'.join(parts)
 
     try:
         thing = getattr(parent, current)
@@ -36,9 +36,9 @@ def process_dep(parent, dep, serialize_me, seen):
             children = [thing]
         add_to_serialize_list(children, serialize_me, seen)
 
-        if remain:
+        if leftover:
             for child in children:
-                process_dep(child, remain, serialize_me, seen)
+                process_dep(child, leftover, serialize_me, seen)
 
 
 class Command(BaseCommand):

--- a/fixture_magic/utils.py
+++ b/fixture_magic/utils.py
@@ -1,8 +1,5 @@
 from django.db import models
 
-serialize_me = []
-seen = {}
-
 
 def reorder_json(data, models, ordering_cond=None):
     """Reorders JSON (actually a list of model dicts).
@@ -45,21 +42,24 @@ def get_fields(obj):
         return []
 
 
-def serialize_fully():
+def serialize_fully(serialize_me, seen):
     index = 0
 
     while index < len(serialize_me):
         for field in get_fields(serialize_me[index]):
             if isinstance(field, models.ForeignKey):
                 add_to_serialize_list(
-                    [serialize_me[index].__getattribute__(field.name)])
+                    [serialize_me[index].__getattribute__(field.name)],
+                    serialize_me,
+                    seen
+                )
 
         index += 1
 
     serialize_me.reverse()
 
 
-def add_to_serialize_list(objs):
+def add_to_serialize_list(objs, serialize_me, seen):
     for obj in objs:
         if obj is None:
             continue
@@ -76,4 +76,4 @@ def add_to_serialize_list(objs):
 
         if key not in seen:
             serialize_me.append(obj)
-            seen[key] = 1
+            seen.add(key)


### PR DESCRIPTION
This fixes the dumping of nested relations and objects.

Also converts script globals to arguments, to allow repeated invocations.

Fixes https://github.com/davedash/django-fixture-magic/issues/39.