### PR TITLE
Add flexible dumps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,9 +46,13 @@ a specific object as well as all its dependencies (as defined by ForeignKeys).
     ## OR
     ./manage.py dump_object APP.MODEL --query '{"pk__in": [PK1, PK2, PK3]}' > my_new_fixture.json
 
-Or you can get all objects with all dependencies by passing an asterisk:
+Or you can get all objects with all dependencies by not specifying the pks:
 
-    ./manage.py dump_object APP.MODEL '*' > my_new_fixture.json
+    ./manage.py dump_object APP.MODEL > my_new_fixture.json
+
+You can also dump objects via a manager method:
+
+    ./manage.py dump_object APP.MODEL.METHOD > my_new_fixture.json
 
 You can now safely load ``my_new_fixture.json`` in a test without foreign key i
 errors.

--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('dump_name')
-        parser.add_argument('pk', nargs='+')
+        parser.add_argument('pk', nargs='*')
         parser.add_argument('--natural', default=False, action='store_true', dest='natural',
                             help='Use natural keys if they are available.')
 
@@ -40,8 +40,11 @@ class Command(BaseCommand):
         dump_settings = settings.CUSTOM_DUMPS[dump_name]
         (app_label, model_name) = dump_settings['primary'].split('.')
         include_primary = dump_settings.get("include_primary", False)
-        dump_me = loading.get_model(app_label, model_name)
-        objs = dump_me.objects.filter(pk__in=[int(i) for i in pks])
+        dump_me = loading.get_model(app_label, model_name).objects
+        if pks:
+            objs = dump_me.filter(pk__in=pks)
+        else:
+            objs = dump_me
         for obj in objs.all():
             # get the dependent objects and add to serialize list
             for dep in dump_settings['dependents']:

--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -38,13 +38,13 @@ class Command(BaseCommand):
         dump_name = options['dump_name']
         pks = options['pk']
         dump_settings = settings.CUSTOM_DUMPS[dump_name]
-        app_label, model_name, *subset = dump_settings['primary'].split('.')
+        app_label, model_name, *manager_method = dump_settings['primary'].split('.')
         include_primary = dump_settings.get("include_primary", False)
-        manager = loading.get_model(app_label, model_name).objects
-        if subset:
-            dump_me = getattr(manager, subset[0])()
+        default_manager = loading.get_model(app_label, model_name).objects
+        if manager_method:
+            dump_me = getattr(default_manager, manager_method[0])()
         else:
-            dump_me = manager
+            dump_me = default_manager
         if pks:
             objs = dump_me.filter(pk__in=pks)
         else:

--- a/fixture_magic/management/commands/custom_dump.py
+++ b/fixture_magic/management/commands/custom_dump.py
@@ -38,9 +38,13 @@ class Command(BaseCommand):
         dump_name = options['dump_name']
         pks = options['pk']
         dump_settings = settings.CUSTOM_DUMPS[dump_name]
-        (app_label, model_name) = dump_settings['primary'].split('.')
+        app_label, model_name, *subset = dump_settings['primary'].split('.')
         include_primary = dump_settings.get("include_primary", False)
-        dump_me = loading.get_model(app_label, model_name).objects
+        manager = loading.get_model(app_label, model_name).objects
+        if subset:
+            dump_me = getattr(manager, subset[0])()
+        else:
+            dump_me = manager
         if pks:
             objs = dump_me.filter(pk__in=pks)
         else:


### PR DESCRIPTION
- Allows dumping all objects, without specifying the PKs.
- Allows selecting objects via model manager methods.